### PR TITLE
chore: ignore env and build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 web-build/
 expo-env.d.ts
 
+# Build output
+build/
+
 # Native
 .kotlin/
 *.orig.*
@@ -31,6 +34,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env
 .env*.local
 
 # typescript


### PR DESCRIPTION
## Summary
- ignore build outputs and environment files in `.gitignore`

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b304116488331984503e29a01e36b