### PR TITLE
Implement pair invite and acceptance with QR scanning

### DIFF
--- a/app/(pair)/accept.tsx
+++ b/app/(pair)/accept.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button, Text } from 'react-native';
+import { BarCodeScanner } from 'expo-barcode-scanner';
+import { supabase } from '../../lib/supabase';
+import { useRouter } from 'expo-router';
+
+/**
+ * Screen used by the invited user to accept a pairing. The user can either
+ * type the 6 digit code or scan a QR code. If the code exists the related
+ * pair is activated and the user is navigated back to the Home screen.
+ */
+export default function AcceptScreen() {
+  const [code, setCode] = useState('');
+  const [hasPermission, setHasPermission] = useState<boolean | null>(null);
+  const [scanning, setScanning] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    (async () => {
+      const { status } = await BarCodeScanner.requestPermissionsAsync();
+      setHasPermission(status === 'granted');
+    })();
+  }, []);
+
+  const handleBarCodeScanned = ({ data }: { data: string }) => {
+    setScanning(false);
+    setCode(data);
+  };
+
+  async function accept() {
+    const { data, error } = await supabase
+      .from('pair_invites')
+      .select('pair_id')
+      .eq('code', code)
+      .single();
+
+    if (error || !data) {
+      alert('Invalid code');
+      return;
+    }
+
+    await supabase
+      .from('pairs')
+      .update({ active: true })
+      .eq('id', data.pair_id);
+
+    router.replace('/');
+  }
+
+  if (hasPermission === false) {
+    return <Text>No access to camera</Text>;
+  }
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      {scanning ? (
+        <BarCodeScanner
+          style={{ flex: 1, width: '100%' }}
+          onBarCodeScanned={handleBarCodeScanned}
+        />
+      ) : (
+        <>
+          <TextInput
+            value={code}
+            onChangeText={setCode}
+            keyboardType="number-pad"
+            style={{ borderWidth: 1, padding: 8, width: 200, marginBottom: 16 }}
+            placeholder="Enter code"
+          />
+          <Button title="Scan QR Code" onPress={() => setScanning(true)} />
+          <Button title="Accept" onPress={accept} />
+        </>
+      )}
+    </View>
+  );
+}

--- a/app/(pair)/invite.tsx
+++ b/app/(pair)/invite.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text } from 'react-native';
+
+/**
+ * Screen that requests a 6 digit invite code from the
+ * `create_pair_invite` edge function and displays it to the user.
+ */
+export default function InviteScreen() {
+  const [code, setCode] = useState<string>('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/functions/v1/create_pair_invite');
+        const json = await res.json();
+        setCode(json.code);
+      } catch (err) {
+        console.error('Failed to create invite', err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text style={{ fontSize: 32, letterSpacing: 8 }}>{code}</Text>
+    </View>
+  );
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const supabase = createClient(
+  process.env.EXPO_PUBLIC_SUPABASE_URL ?? '',
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? ''
+);

--- a/supabase/functions/create_pair_invite/index.ts
+++ b/supabase/functions/create_pair_invite/index.ts
@@ -1,0 +1,26 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Edge function that generates a random 6 digit code and stores it in the
+ * `pair_invites` table. Returns the created code to the caller.
+ */
+serve(async (req) => {
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+  const { error } = await supabase.from('pair_invites').insert({ code });
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ code }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+});


### PR DESCRIPTION
## Summary
- add screens for creating and accepting pair invites
- implement `create_pair_invite` edge function storing generated 6-digit codes
- enable accepting invites via manual entry or QR scan

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689b267e6eb083318747c24d4079edfc