### PR TITLE
Add tests for Supabase service functions

### DIFF
--- a/__tests__/supabaseService.test.ts
+++ b/__tests__/supabaseService.test.ts
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+
+const mockSelect = jest.fn<() => Promise<any>>();
+const mockInsert = jest.fn<(arg: any) => Promise<any>>();
+const mockFrom = jest.fn<(table: string) => any>();
+
+jest.mock('@supabase/supabase-js', () => ({
+  __esModule: true,
+  createClient: jest.fn(() => ({ from: mockFrom })),
+}));
+
+import { fetchPosts, addPost } from '../lib/supabaseService';
+
+describe('fetchPosts', () => {
+  beforeEach(() => {
+    mockFrom.mockReset();
+    mockSelect.mockReset();
+  });
+
+  it('returns posts on success', async () => {
+    const posts = [{ id: 1, title: 'Test' }];
+    mockFrom.mockReturnValueOnce({ select: mockSelect });
+    mockSelect.mockResolvedValueOnce({ data: posts, error: null });
+
+    const result = await fetchPosts();
+
+    expect(result).toEqual(posts);
+    expect(mockFrom).toHaveBeenCalledWith('posts');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+  });
+
+  it('throws on error', async () => {
+    const error = new Error('fetch failed');
+    mockFrom.mockReturnValueOnce({ select: mockSelect });
+    mockSelect.mockResolvedValueOnce({ data: null, error });
+
+    await expect(fetchPosts()).rejects.toThrow('fetch failed');
+  });
+});
+
+describe('addPost', () => {
+  beforeEach(() => {
+    mockFrom.mockReset();
+    mockInsert.mockReset();
+  });
+
+  it('returns inserted post on success', async () => {
+    const newPost = { title: 'New Post' };
+    const inserted = { id: 1, ...newPost };
+    mockFrom.mockReturnValueOnce({ insert: mockInsert });
+    mockInsert.mockResolvedValueOnce({ data: inserted, error: null });
+
+    const result = await addPost(newPost);
+
+    expect(result).toEqual(inserted);
+    expect(mockFrom).toHaveBeenCalledWith('posts');
+    expect(mockInsert).toHaveBeenCalledWith(newPost);
+  });
+
+  it('throws on error', async () => {
+    const error = new Error('insert failed');
+    const newPost = { title: 'New Post' };
+    mockFrom.mockReturnValueOnce({ insert: mockInsert });
+    mockInsert.mockResolvedValueOnce({ data: null, error });
+
+    await expect(addPost(newPost)).rejects.toThrow('insert failed');
+  });
+});

--- a/lib/supabaseService.ts
+++ b/lib/supabaseService.ts
@@ -1,0 +1,18 @@
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
+const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+export async function fetchPosts() {
+  const { data, error } = await supabase.from('posts').select('*');
+  if (error) throw error;
+  return data;
+}
+
+export async function addPost(post: Record<string, any>) {
+  const { data, error } = await supabase.from('posts').insert(post);
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## Summary
- add Supabase service with `fetchPosts` and `addPost`
- write Jest tests mocking Supabase client for success and error cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b3f5a34348331bf4752ffdfc6df9a