### PR TITLE
Add calendar suggestion edge function

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,20 @@ Prototype showcasing surprise pack purchases powered by RevenueCat and Supabase.
 - RevenueCat is configured via `NEXT_PUBLIC_RC_API_KEY`.
 - Purchases are stored in the `purchases` table using Supabase credentials.
 - Edge function `reconcile_entitlements` syncs RevenueCat entitlements.
+- Edge function `generate_suggestions` queries calendar data to suggest free meeting slots.
 
 Run tests (none defined yet):
 
 ```
 npm test
+```
+
+### Deploy edge functions
+
+Deploy the suggestions function to your Supabase project:
+
+```
+supabase functions deploy generate_suggestions
 ```
 =======
 # Welcome to your Expo app 👋

--- a/supabase/functions/generate_suggestions/index.ts
+++ b/supabase/functions/generate_suggestions/index.ts
@@ -1,0 +1,62 @@
+import { serve } from "https://deno.land/std@0.192.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export async function generateSuggestions(req: Request): Promise<Response> {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const { pair_id } = await req.json();
+  if (!pair_id) {
+    return new Response(JSON.stringify({ error: "pair_id is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+  const endOfDay = new Date(startOfDay);
+  endOfDay.setDate(endOfDay.getDate() + 1);
+
+  const { data: busy, error } = await supabase
+    .from("calendar_busy")
+    .select("start_time,end_time")
+    .eq("pair_id", pair_id)
+    .gte("end_time", startOfDay.toISOString())
+    .lt("start_time", endOfDay.toISOString())
+    .order("start_time", { ascending: true });
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const free: { start: string; end: string }[] = [];
+  let cursor = startOfDay;
+
+  for (const slot of busy ?? []) {
+    const busyStart = new Date(slot.start_time);
+    const busyEnd = new Date(slot.end_time);
+
+    if (cursor < busyStart) {
+      free.push({ start: cursor.toISOString(), end: busyStart.toISOString() });
+    }
+
+    if (cursor < busyEnd) {
+      cursor = busyEnd;
+    }
+  }
+
+  if (cursor < endOfDay) {
+    free.push({ start: cursor.toISOString(), end: endOfDay.toISOString() });
+  }
+
+  return new Response(JSON.stringify({ slots: free }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+serve(generateSuggestions);

--- a/supabase/functions/index.ts
+++ b/supabase/functions/index.ts
@@ -1,0 +1,7 @@
+// List of available edge functions
+export const edgeFunctions = [
+  'create_pair_invite',
+  'push_notify',
+  'reconcile_entitlements',
+  'generate_suggestions',
+];


### PR DESCRIPTION
## Summary
- add `generate_suggestions` edge function to compute free slots from pair calendar
- list edge functions in `supabase/functions/index.ts`
- document deployment for suggestion function in README

## Testing
- `npm test` *(fails: Invalid package.json: JSON.parse Error)*

------
https://chatgpt.com/codex/tasks/task_e_689b415fec2c83318514ac30e8716f1e