### PR TITLE
feat: add auth session helper for OAuth providers

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,9 @@
     "scheme": "tempapp",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
+    "extra": {
+      "authRedirect": "tempapp://auth/callback"
+    },
     "ios": {
       "supportsTablet": true
     },

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '../../lib/supabase'
+import { signInWithOAuth, OAuthProvider } from '../../lib/authSession'
 
 export default function Login() {
   const [email, setEmail] = useState('')
@@ -15,8 +16,13 @@ export default function Login() {
     if (!error) router.push('/')
   }
 
-  const handleOAuth = async (provider: 'google' | 'github') => {
-    await supabase.auth.signInWithOAuth({ provider })
+  const handleOAuth = async (provider: OAuthProvider) => {
+    try {
+      await signInWithOAuth(provider)
+      router.push('/')
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (
@@ -38,7 +44,8 @@ export default function Login() {
         <button type="submit">Login</button>
       </form>
       <button onClick={() => handleOAuth('google')}>Login with Google</button>
-      <button onClick={() => handleOAuth('github')}>Login with GitHub</button>
+      <button onClick={() => handleOAuth('apple')}>Login with Apple</button>
+      <button onClick={() => handleOAuth('azure')}>Login with Outlook</button>
     </div>
   )
 }

--- a/lib/authSession.ts
+++ b/lib/authSession.ts
@@ -1,0 +1,37 @@
+import * as AuthSession from 'expo-auth-session';
+import { supabase } from './supabase';
+
+export type OAuthProvider = 'google' | 'apple' | 'azure';
+
+export async function signInWithOAuth(provider: OAuthProvider) {
+  // Build redirect URL based on the app.json scheme
+  const redirectTo = AuthSession.makeRedirectUri({
+    useProxy: true,
+    scheme: 'tempapp',
+  });
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: {
+      redirectTo,
+      skipBrowserRedirect: true,
+    },
+  });
+
+  if (error) throw error;
+
+  const authUrl = data?.url;
+  if (!authUrl) throw new Error('Failed to get auth URL');
+
+  const result = await AuthSession.startAsync({ authUrl, returnUrl: redirectTo });
+
+  if (result.type === 'success' && result.params?.code) {
+    const { error: exchangeError } = await supabase.auth.exchangeCodeForSession({
+      provider,
+      code: result.params.code,
+    });
+    if (exchangeError) throw exchangeError;
+  } else {
+    throw new Error('OAuth flow was cancelled');
+  }
+}


### PR DESCRIPTION
## Summary
- create authSession helper wrapping expo-auth-session and Supabase OAuth
- switch login screen to use helper for Google, Apple, and Outlook sign-in
- add app.json config for auth redirect URI

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_689b41bb282483319f29bb3ac3b8f5a0