### PR TITLE
feat: add expo auth session helper

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,10 +8,12 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.example.tempapp"
     },
     "android": {
-      "edgeToEdgeEnabled": true
+      "edgeToEdgeEnabled": true,
+      "package": "com.example.tempapp"
     },
     "web": {
       "bundler": "metro",
@@ -20,6 +22,12 @@
     "plugins": ["expo-router"],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "supabaseRedirectUrl": "tempapp://auth",
+      "googleClientId": "GOOGLE_CLIENT_ID",
+      "appleClientId": "APPLE_CLIENT_ID",
+      "outlookClientId": "OUTLOOK_CLIENT_ID"
     }
   }
 }

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '../../lib/supabase'
+import { signInWithOAuth, OAuthProvider } from '../../lib/authSession'
 
 export default function Login() {
   const [email, setEmail] = useState('')
@@ -15,8 +16,13 @@ export default function Login() {
     if (!error) router.push('/')
   }
 
-  const handleOAuth = async (provider: 'google' | 'github') => {
-    await supabase.auth.signInWithOAuth({ provider })
+  const handleOAuth = async (provider: OAuthProvider) => {
+    try {
+      await signInWithOAuth(provider)
+      router.push('/')
+    } catch (e) {
+      console.error(e)
+    }
   }
 
   return (
@@ -38,7 +44,8 @@ export default function Login() {
         <button type="submit">Login</button>
       </form>
       <button onClick={() => handleOAuth('google')}>Login with Google</button>
-      <button onClick={() => handleOAuth('github')}>Login with GitHub</button>
+      <button onClick={() => handleOAuth('apple')}>Login with Apple</button>
+      <button onClick={() => handleOAuth('azure')}>Login with Outlook</button>
     </div>
   )
 }

--- a/lib/authSession.ts
+++ b/lib/authSession.ts
@@ -1,0 +1,32 @@
+import * as AuthSession from 'expo-auth-session'
+import * as WebBrowser from 'expo-web-browser'
+
+import { supabase, redirectTo } from './supabase'
+
+WebBrowser.maybeCompleteAuthSession()
+
+export type OAuthProvider = 'google' | 'apple' | 'azure'
+
+// Initiates an OAuth flow using expo-auth-session and exchanges the
+// resulting code for a Supabase session.
+export async function signInWithOAuth(provider: OAuthProvider) {
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: { redirectTo }
+  })
+
+  if (error) throw error
+
+  const authUrl = data?.url
+  if (!authUrl) throw new Error('No auth URL returned')
+
+  const result = await AuthSession.startAsync({ authUrl, returnUrl: redirectTo })
+
+  if (result.type !== 'success') throw new Error('OAuth flow canceled')
+
+  const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(
+    result.params
+  )
+  if (exchangeError) throw exchangeError
+}
+

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,16 +1,21 @@
-
 import { createClient } from '@supabase/supabase-js'
+import { makeRedirectUri } from 'expo-auth-session'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL as string,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
-)
+// Determine Supabase credentials from environment variables for both
+// Expo and Next.js environments.
+const supabaseUrl =
+  process.env.EXPO_PUBLIC_SUPABASE_URL ??
+  process.env.NEXT_PUBLIC_SUPABASE_URL ??
+  ''
 
+const supabaseAnonKey =
+  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  ''
 
-import { createClient } from '@supabase/supabase-js';
+// Shared Supabase client used across the application
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
 
-export const supabase = createClient(
-  process.env.EXPO_PUBLIC_SUPABASE_URL ?? '',
-  process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? ''
-);
+// Redirect URI used for OAuth flows with expo-auth-session
+export const redirectTo = makeRedirectUri({ scheme: 'tempapp' })
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "expo-symbols": "0.4.5",
     "expo-system-ui": "5.0.10",
     "expo-web-browser": "14.2.0",
+    "expo-auth-session": "^5.0.0",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.5",


### PR DESCRIPTION
## Summary
- add reusable expo-auth-session OAuth helper for Google, Apple, and Outlook
- use helper in login screen and configure redirect handling
- declare OAuth credentials and redirect URI in Expo config

## Testing
- `npm test` *(fails: Invalid package.json: JSONParseError)*

------
https://chatgpt.com/codex/tasks/task_e_689b426103608331bec982236aa68fab